### PR TITLE
fix pytz dependency requirement to be PEP compliant

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-pytz>dev
+pytz>0.dev.0
 billiard>=3.6.3.0,<4.0
 kombu>=4.6.10,<4.7
 vine==1.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
-pytz>dev
+pytz>0.dev.0
 git+https://github.com/celery/kombu.git
 git+https://github.com/celery/py-amqp.git
 git+https://github.com/celery/billiard.git


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
